### PR TITLE
Tackle-331: Upgrading to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains the files for Tackle documentation. Tackle is part of t
 
 ## Submitting issues
 
-Can submit issues at [konveyor/tackle-operator/issues](https://github.com/konveyor/tackle-operator/issues).
+You can submit issues at [konveyor/tackle-operator/issues](https://github.com/konveyor/tackle-operator/issues).
 
 ## Contributing to Tackle documentation
 

--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ asciidoctor:
   - oc=kubectl
   - ocp=Enterprise Kubernetes Platform
   - ocp-version=
-  - project-version=1.0
+  - project-version=1.1
   - operator=Tackle Operator
   - namespace=my-tackle-operator
   - kebab=Options menu image:kebab.png[title="Options menu",height=20]

--- a/documentation/doc-installing-and-using-tackle/master.adoc
+++ b/documentation/doc-installing-and-using-tackle/master.adoc
@@ -78,3 +78,5 @@ include::modules/creating-tag-type.adoc[leveloffset=+2]
 include::modules/creating-tag.adoc[leveloffset=+2]
 
 include::modules/about-reports.adoc[leveloffset=+1]
+
+include::modules/upgrading.adoc[leveloffset=+1]

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -3,8 +3,8 @@
 
 // text attributes
 :kebab: Options menu image:kebab.png[title="Options menu",height=20]
-:project-name: MTA Pathfinder
-:project-version: 1.0
+:project-name: Pathfinder
+:project-version: 1.1
 :namespace:
 :ocp: OpenShift Container Platform
 :ocp-version: 4.9

--- a/documentation/modules/installing-operator.adoc
+++ b/documentation/modules/installing-operator.adoc
@@ -38,7 +38,7 @@ You download and install the {operator} on an {ocp} cluster.
 +
 [source,terminal]
 ----
-$ kubectl create -f https://operatorhub.io/install/tackle-operator.yaml
+$ {oc} create -f https://operatorhub.io/install/tackle-operator.yaml
 ----
 +
 The {operator} is installed in the +{namespace}+ namespace.

--- a/documentation/modules/installing-tackle-application.adoc
+++ b/documentation/modules/installing-tackle-application.adoc
@@ -33,7 +33,7 @@ You install the {project-name} application in a namespace by instantiating the {
 +
 [source,terminal,subs="attributes+"]
 ----
-$ kubectl apply -n {namespace} -f https://raw.githubusercontent.com/konveyor/tackle-operator/main/src/main/resources/k8s/tackle/tackle.yaml
+$ {oc} apply -n {namespace} -f https://raw.githubusercontent.com/konveyor/tackle-operator/main/src/main/resources/k8s/tackle/tackle.yaml
 ----
 
 . In the Kubernetes dashboard, click *Workloads* -> *Deployments* to verify the installation.

--- a/documentation/modules/upgrading.adoc
+++ b/documentation/modules/upgrading.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-installing-and-using-tackle/master.adoc
+
+[id="upgrading_{context}"]
+= Upgrading {project-name}
+
+You can manually upgrade {project-name} from version 1.0.0 to 1.1.0.
+
+.Procedure
+
+. Update the `tackle-keycloak` deployment:
++
+[source,terminal,subs="attributes+"]
+----
+$ {oc} -n {namespace} exec deployments/tackle-keycloak -c tackle-keycloak -- bash -c '/opt/jboss/keycloak/bin/kcadm.sh update realms/tackle -s internationalizationEnabled=true -s supportedLocales+=en -s supportedLocales+=es -s defaultLocale=en --server http://localhost:8080/auth --realm master --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD'
+----
+
+. Update the `tackle-application-inventory-rest` deployment:
++
+[source,terminal,subs="attributes+"]
+----
+$ {oc} set image -n {namespace} deployment/tackle-application-inventory-rest tackle-application-inventory-rest=quay.io/konveyor/tackle-application-inventory:1.1.0-native
+----
+
+. Update the `tackle-controls-rest` deployment:
++
+[source,terminal,subs="attributes+"]
+----
+$ {oc} set image -n {namespace} deployment/tackle-controls-rest tackle-controls-rest=quay.io/konveyor/tackle-controls:1.1.0-native
+----
+
+. Update the `tackle-pathfinder-rest` deployment:
++
+[source,terminal,subs="attributes+"]
+----
+$ {oc} set image -n {namespace} deployment/tackle-pathfinder-rest tackle-pathfinder-rest=quay.io/konveyor/tackle-pathfinder:1.1.0-native
+----
+
+. Update the `tackle-ui` deployment:
++
+[source,terminal,subs="attributes+"]
+----
+$ {oc} set image -n {namespace} deployment/tackle-ui tackle-ui=quay.io/konveyor/tackle-ui:1.1.0
+----
+
+. Log in to the web console and click the Help icon beside the user name to verify the upgrade.
++
+The *About {project-name}* window opens and displays the version number.

--- a/index.adoc
+++ b/index.adoc
@@ -8,4 +8,4 @@ Tackle is a tool in the link:https://konveyor.io/[Konveyor community] for refact
 
 ## Documentation
 
-* link:documentation/doc-installing-and-using-tackle/master/index.html[Installing and using Tackle] (1.0). June 30, 2021.
+* link:documentation/doc-installing-and-using-tackle/master/index.html[Installing and using Tackle] (1.1). Nov 21, 2021.


### PR DESCRIPTION
https://issues.redhat.com/browse/TACKLE-331

Preview: https://deploy-preview-49--tackle-documentation.netlify.app/documentation/doc-installing-and-using-tackle/master/index.html#upgrading_tackle