### PR TITLE
Updates Tackle version number and documentation publication date

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ asciidoctor:
   - oc=kubectl
   - ocp=Enterprise Kubernetes Platform
   - ocp-version=
-  - project-version=1.1
+  - project-version=1.2
   - operator=Tackle Operator
   - namespace=my-tackle-operator
   - kebab=Options menu image:kebab.png[title="Options menu",height=20]

--- a/index.adoc
+++ b/index.adoc
@@ -8,4 +8,4 @@ Tackle is a tool in the link:https://konveyor.io/[Konveyor community] for refact
 
 ## Documentation
 
-* link:documentation/doc-installing-and-using-tackle/master/index.html[Installing and using Tackle] (1.1). Nov 21, 2021.
+* link:documentation/doc-installing-and-using-tackle/master/index.html[Installing and using Tackle] (1.2). February 1, 2022.


### PR DESCRIPTION
Tackle 1.2

1. Updates the version number in _config yml
2. Updates the version number and publication date in index.adoc (will affect https://tackle-docs.konveyor.io/ when merged).
